### PR TITLE
Fix windows template cloner

### DIFF
--- a/from-template.bat
+++ b/from-template.bat
@@ -4,6 +4,8 @@ set PROTOCOL=%1
 set REPO=%2
 set DEST=%3
 
+if exist %DEST% goto :dir_exists
+
 call git clone "%PROTOCOL%%REPO%.git" %DEST%
 
 if not exist %DEST% goto :clone_failed
@@ -13,6 +15,12 @@ cd %DEST%
 rd /s /q .git
 
 goto :exit
+
+:dir_exists
+
+echo "Directory already exists. Choose a different name."
+
+exit /b 1
 
 :clone_failed
 

--- a/from-template.bat
+++ b/from-template.bat
@@ -18,7 +18,7 @@ goto :exit
 
 :dir_exists
 
-echo "Directory already exists. Choose a different name."
+echo "Directory %DEST% already exists. Choose a different name."
 
 exit /b 1
 


### PR DESCRIPTION
Previously, 

> raco new <template> <destination> 
would overwrite any file named <destination>. It will now fail and ask you to pick a new directory name in order to proceed with cloning the template. 